### PR TITLE
add support for nim

### DIFF
--- a/reple/configs/nim.json
+++ b/reple/configs/nim.json
@@ -1,0 +1,22 @@
+{
+    "run": "{bin_fname}",
+    "compile" : "{compiler} {user_cargs} {cflags} {code_fname} # -o:{bin_fname}",
+    "compile_args": {
+        "compiler": "nim",
+        "code_suffix": ".nim",
+        "cflags": "c"
+    },
+    "template": "{template_begin}\n{prolog_lines}\n{template_main_begin}\n{repl_lines}\n{template_end}\n",
+    "template_args": {
+        "template_begin": "import strformat, strutils",
+        "template_main_begin": "",
+        "template_end": "",
+        "line_epilogue": ""
+    },
+    "terminal_opts": {
+        "lexer_fn": "NimrodLexer",
+        "lexer_class": "pygments.lexers",
+        "prolog_char": "$",
+        "enclosers": []
+    }
+}

--- a/reple/configs/nim.json
+++ b/reple/configs/nim.json
@@ -4,7 +4,7 @@
     "compile_args": {
         "compiler": "nim",
         "code_suffix": ".nim",
-        "cflags": "c"
+        "cflags": "c --hints:off --verbosity:0"
     },
     "template": "{template_begin}\n{prolog_lines}\n{template_main_begin}\n{repl_lines}\n{template_end}\n",
     "template_args": {


### PR DESCRIPTION
Probably can be much better 

1- can't specify the `bin_fname` without `--run` flag in the compiler which will run the file automatically (leading to overlapping output) that's why i added it after hash `#` so reple doesn't barf
2- nim is a whitespace sensitive language are there any other flags I need to take care of? 
