### PR TITLE
Allow not specifying a lexer

### DIFF
--- a/reple/reple.py
+++ b/reple/reple.py
@@ -111,7 +111,7 @@ class Reple:
         self.runtime_env = runtime_env
         self.code_templ = code_templ
 
-        self.lexer = PygmentsLexer(lexer)
+        self.lexer = None if lexer is None else PygmentsLexer(lexer)
         self.output_dir = output_dir
 
         self.prolog_lines = []


### PR DESCRIPTION
reple seems to only use the lexer for syntax highlighting, which is nice but not
strictly necessary for a repl to be useful. Some languages may not have a
suitable lexer available or may wish to prioritize basic support first and add
color later.

This is the first of a couple small changes I'm requesting to add support for Pony: [https://github.com/ponylang/](https://github.com/ponylang/)