### PR TITLE
feat: allow -f option to accept a file path

### DIFF
--- a/reple/reple.py
+++ b/reple/reple.py
@@ -251,10 +251,14 @@ def configure_terminal_opts(terminal_opts):
 
 def get_config_fname(args):
     reple_path = os.path.dirname(os.path.realpath(__file__))
-    fname = reple_path + '/configs/'
-    if args.fname is not None:
-        fname += args.fname
-        return fname
+    fname = args.fname
+
+    if fname is not None:
+        if os.path.isfile(fname):
+            return fname
+        else:
+            fname = reple_path + '/configs/' + args.fname
+            return fname
     else:
         fname = reple_path + '/config/reple/' + args.env + '.json'
         if os.path.isfile(fname):


### PR DESCRIPTION
I've been using reple for a while and it's been great! But I found I can't specify my local config file with `-f` option.
Although I've seen it was mentioned in #4, it seemed not work for me.
```
$ reple -f /tmp/cxx.json
Traceback (most recent call last):
  File "/home/cycatz/workspace/reple/reple/reple", line 8, in <module>
    reple.run_reple(sys.argv[1:])
  File "/home/cycatz/workspace/reple/reple/reple.py", line 283, in run_reple
    config = json.load(open(fname, 'r'))
FileNotFoundError: [Errno 2] No such file or directory: '/home/cycatz/workspace/reple/reple/configs//tmp/cxx.json'
```

So I slightly modified the `get_config_fname` function, here are the steps:
1. try to use the argument as the file path if the file exists; 
2. otherwise, fallback to use it as a config name to find under reple `configs` directory.